### PR TITLE
fix bug in get_arguments

### DIFF
--- a/app/cli.f90
+++ b/app/cli.f90
@@ -28,11 +28,11 @@ contains
     integer :: iarg, narg
     character(len=:), allocatable :: arg
 
-    iarg = 1
+    iarg = 0
     narg = command_argument_count()
-    do while(iarg <= narg)
-      call get_argument(iarg, arg)
+    do while(iarg < narg)
       iarg = iarg + 1
+      call get_argument(iarg, arg)
       select case(arg)
       case("--help")
         call printout(report, help_text)

--- a/app/cli.f90
+++ b/app/cli.f90
@@ -28,11 +28,11 @@ contains
     integer :: iarg, narg
     character(len=:), allocatable :: arg
 
-    iarg = 0
+    iarg = 1
     narg = command_argument_count()
     do while(iarg <= narg)
-      iarg = iarg + 1
       call get_argument(iarg, arg)
+      iarg = iarg + 1
       select case(arg)
       case("--help")
         call printout(report, help_text)


### PR DESCRIPTION
The flox doesn't correctly parse the command line arguments as they are passed in. e.g.
```
./path/to/flox input_file
```